### PR TITLE
Fix comments about reloading components

### DIFF
--- a/cpp_demos/DW_SDK_Cpp_Example/DW UnsupervisedDefectSegmentation/main.cpp
+++ b/cpp_demos/DW_SDK_Cpp_Example/DW UnsupervisedDefectSegmentation/main.cpp
@@ -369,6 +369,8 @@ int main() {
         ComponentMemory component = model.createComponentMemory("screw", good_images, {}, {}, true);
         std::string compFile = (fs::path(folderPath) / "component_1.pth").string();
         component.save(compFile);
+        // 若需在后续单独加载该组件，可这样调用:
+        // auto loadedComponent = model.addComponentMemory("screw", "file_path");
         model.setBatchSize(1);
         std::cout << "Component memory saved to " << compFile << std::endl;
 

--- a/cs_demos/unsupervised_defect_segmentation/unsupervised_defect_segmentation/Program.cs
+++ b/cs_demos/unsupervised_defect_segmentation/unsupervised_defect_segmentation/Program.cs
@@ -373,6 +373,8 @@ namespace UnsupervisedDefectSegmentationDemo
                 var component = unsupervisedModel.createComponentMemory("screw", goodImages.ToArray(), badImages.ToArray(), masksList.ToArray(), true);
                 string compFile = Path.Combine(folderPath, "component_1.pth");
                 component.save(compFile);
+                // 若要在后续程序中重新加载该组件，可这样使用：
+                // var componentReload = unsupervisedModel.addComponentMemory("screw", "file_path");
                 unsupervisedModel.setBatchSize(1);
                 
                 Console.WriteLine("训练组件已保存到: " + compFile);

--- a/python_demos/unsupervised_defect_segmentation_demo.py
+++ b/python_demos/unsupervised_defect_segmentation_demo.py
@@ -301,6 +301,8 @@ def main():
     component = model_instance.createComponentMemory("screw", good_images, bad_images, masks_list, True)
     compFile = os.path.join(folderPath, "component_1.pth")
     component.save(compFile)
+    # 训练后如果需要再次加载该组件，可使用:
+    # component = model_instance.addComponentMemory("screw", "file_path")
     model_instance.setBatchSize(1)
     print("Component memory saved to", compFile)
 


### PR DESCRIPTION
## Summary
- update comments for component reloading in C++, C#, and Python demos
- clarify that the second argument of `addComponentMemory` is the file path

## Testing
- `python3 -m py_compile python_demos/unsupervised_defect_segmentation_demo.py`


------
https://chatgpt.com/codex/tasks/task_e_686301dda824832585b9a6faf9c34637