### PR TITLE
Add local speed computation to traffic post processor

### DIFF
--- a/python_demos/video_surveillance_demo/websocket_client/traffic_post_processor.py
+++ b/python_demos/video_surveillance_demo/websocket_client/traffic_post_processor.py
@@ -11,6 +11,9 @@ import requests
 import websockets
 from redis import asyncio as aioredis
 import redis
+import cv2
+import numpy as np
+import math
 
 # Flags that represent vehicle classes in the received JSON. These are used
 # when attempting to categorise a detected vehicle from the flags field. The
@@ -38,6 +41,12 @@ track_centers: Dict[int, Dict[int, Tuple[float, float]]] = defaultdict(dict)
 # speed_histories[camera_id] -> deque[(timestamp, speed)] for running average
 speed_histories: Dict[int, deque] = defaultdict(deque)
 
+# tracking state for computing object speeds
+speed_states: Dict[int, Dict[int, Dict[str, object]]] = defaultdict(dict)
+
+# configuration for speed computation per camera
+speed_configs: Dict[int, Dict[str, object]] = {}
+
 # Placeholder redis client for persisting statistics
 redis_client: aioredis.Redis | None = None
 
@@ -62,6 +71,107 @@ def iou(box1: Tuple[float, float, float, float], box2: Tuple[float, float, float
         return 0.0
 
     return inter_area / union_area
+
+
+def _compute_homography(
+    polygon: List[Tuple[float, float]], edge_distances: List[float]
+) -> np.ndarray:
+    src = np.array(polygon, dtype=np.float32)
+
+    dst = [np.array([0.0, 0.0], dtype=np.float32)]
+    for i in range(1, len(src)):
+        vec = src[i] - src[i - 1]
+        pix_len = float(np.linalg.norm(vec)) or 1.0
+        scale = edge_distances[i - 1] / pix_len
+        dst.append(dst[i - 1] + vec * scale)
+
+    dst = np.array(dst, dtype=np.float32)
+
+    if len(src) == 4:
+        H = cv2.getPerspectiveTransform(src, dst)
+    else:
+        H, _ = cv2.findHomography(src, dst)
+    return H
+
+
+def compute_speeds_inplace(
+    dets: List[Dict[str, object]],
+    timestamp: int,
+    polygon: List[Tuple[float, float]],
+    edge_distances: List[float],
+    states: Dict[int, Dict[str, object]],
+    smoothing_window: int = 1,
+    unit: str = "kmh",
+) -> None:
+    H = _compute_homography(polygon, edge_distances)
+    for det in dets:
+        box = det.get("box")
+        tracker_id = det.get("tracker")
+        if box is None or tracker_id is None:
+            continue
+        cx = (box[0] + box[2]) / 2.0
+        cy = (box[1] + box[3]) / 2.0
+        world = cv2.perspectiveTransform(
+            np.array([[[cx, cy]]], dtype=np.float32), H
+        )[0][0]
+        state = states.get(tracker_id, {"last_pos": None, "last_time": None, "speeds": []})
+        last_pos = state["last_pos"]
+        last_time = state["last_time"]
+        speeds = state["speeds"]
+        speed_mps = 0.0
+        if last_pos is not None and last_time is not None and timestamp > last_time:
+            dx = world[0] - last_pos[0]
+            dy = world[1] - last_pos[1]
+            dist = math.hypot(dx, dy)
+            dt = (timestamp - last_time) / 1000.0
+            if dt > 0:
+                inst_speed = dist / dt
+                speeds.append(inst_speed)
+                if smoothing_window > 1:
+                    speeds = speeds[-smoothing_window:]
+                speed_mps = sum(speeds) / len(speeds)
+            else:
+                speeds = []
+        states[tracker_id] = {"last_pos": world, "last_time": timestamp, "speeds": speeds}
+        if unit == "kmh":
+            det["speed"] = float(speed_mps * 3.6)
+        elif unit == "cms":
+            det["speed"] = float(speed_mps * 100.0)
+        else:
+            det["speed"] = float(speed_mps)
+        det["speed_unit"] = unit
+
+
+def ensure_speed_config(camera_id: int, data: Dict[str, object]) -> None:
+    if camera_id in speed_configs:
+        return
+    node_defs = data.get("node_defs", {})
+    for node in node_defs.values():
+        if not isinstance(node, dict):
+            continue
+        if node.get("type") != "dataProcessing":
+            continue
+        cfg = node.get("data") or {}
+        if cfg.get("type") != "object_movement_speed":
+            continue
+        polygon = cfg.get("polygon")
+        edge_distances = cfg.get("edge_distances")
+        if not polygon or not edge_distances:
+            continue
+        try:
+            polygon = [tuple(map(float, p)) for p in polygon]
+            edge_distances = [float(x) for x in edge_distances]
+        except Exception:
+            continue
+        unit = cfg.get("unit", "kmh")
+        smoothing = int(cfg.get("smoothing_window", 1))
+        speed_configs[camera_id] = {
+            "polygon": polygon,
+            "edge_distances": edge_distances,
+            "unit": unit,
+            "smoothing_window": smoothing,
+        }
+        break
 
 
 
@@ -161,6 +271,8 @@ async def handle_message(msg: str) -> None:
         logger.warning("camera_id missing in message")
         return
 
+    ensure_speed_config(camera_id, data)
+
     wrong_way_detected = False
     accident_detected = False
     abnormal_stop_detected = False
@@ -213,6 +325,19 @@ async def handle_message(msg: str) -> None:
                     det["cls"] = lbl.lower()
 
     detections = list(detections_by_tracker.values())
+
+    cfg = speed_configs.get(camera_id)
+    if cfg:
+        ts = int(data.get("timestamp") or int(time.time() * 1000))
+        compute_speeds_inplace(
+            detections,
+            ts,
+            cfg["polygon"],
+            cfg["edge_distances"],
+            speed_states[camera_id],
+            cfg.get("smoothing_window", 1),
+            cfg.get("unit", "kmh"),
+        )
 
     # Tally vehicles found in this frame for reporting
     frame_counts: Dict[str, int] = defaultdict(int)


### PR DESCRIPTION
## Summary
- compute vehicle speed locally using previous detections
- parse speed configuration from message metadata
- use computed speed in traffic analyzer logic

## Testing
- `python -m py_compile python_demos/video_surveillance_demo/websocket_client/traffic_post_processor.py`


------
https://chatgpt.com/codex/tasks/task_e_686ea1068e1083258d88302864b152ee