### PR TITLE
Implement alert logging for traffic events

### DIFF
--- a/python_demos/video_surveillance_demo/websocket_client/traffic_post_processor.py
+++ b/python_demos/video_surveillance_demo/websocket_client/traffic_post_processor.py
@@ -31,7 +31,25 @@ EXPECTED_SPEED = 100
 ACCIDENT_NODE_ID = "5416394f-7193-409c-aec2-5f4a435317db"
 CAMERA_IDS = [4]
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+BASE_DIR = os.path.dirname(__file__)
+ALERT_DIR = os.path.join(BASE_DIR, "alert")
+LOG_FILE = os.path.join(BASE_DIR, "logs.txt")
+os.makedirs(ALERT_DIR, exist_ok=True)
+
+# startup time and cooldown configuration
+STARTUP_DELAY = 10.0  # seconds before alerts are persisted
+SCRIPT_START_TIME = time.time()
+EVENT_COOLDOWN = 10.0  # minimum seconds between same event type
+last_event_time: Dict[str, float] = defaultdict(float)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.StreamHandler(),
+        logging.FileHandler(LOG_FILE, encoding="utf-8"),
+    ],
+)
 logger = logging.getLogger(__name__)
 
 # vehicle_counts[camera_id][category] -> count
@@ -226,6 +244,40 @@ def get_latest_camera_frame(camera_id: int) -> bytes | None:
     return None
 
 
+def save_alert(event_type: str, message: str, image_key: str | None, camera_id: int) -> None:
+    """Persist alert log and related image under ALERT_DIR."""
+    now = time.time()
+    if now - SCRIPT_START_TIME < STARTUP_DELAY:
+        return
+    last = last_event_time.get(event_type, 0.0)
+    if now - last < EVENT_COOLDOWN:
+        last_event_time[event_type] = now
+        return
+    last_event_time[event_type] = now
+    ts = int(now * 1000)
+    event_dir = os.path.join(ALERT_DIR, event_type)
+    os.makedirs(event_dir, exist_ok=True)
+    log_path = os.path.join(event_dir, f"{ts}.txt")
+    with open(log_path, "w", encoding="utf-8") as f:
+        f.write(message)
+
+    image_bytes = None
+    if image_key:
+        try:
+            parts = image_key.split(":")
+            if len(parts) == 4:
+                cid = int(parts[1])
+                ts_img = int(parts[3])
+                image_bytes = get_camera_frame(cid, ts_img)
+        except Exception:
+            image_bytes = None
+    if not image_bytes:
+        image_bytes = get_latest_camera_frame(camera_id)
+    if image_bytes:
+        with open(os.path.join(event_dir, f"{ts}.jpg"), "wb") as img_f:
+            img_f.write(image_bytes)
+
+
 API_ENDPOINT = os.getenv("API_SERVER", "http://localhost:38080")
 
 # workflow and node constants for traffic statistics
@@ -402,19 +454,31 @@ async def handle_message(msg: str) -> None:
                     if not entry.get("detected") and now - float(entry["start"]) >= 3:
                         accident = await check_accident(image_key)
                         if accident:
-                            logger.warning(
-                                "Camera %s tracker %s \u68c0\u6d4b\u5230\u4ea4\u901a\u4e8b\u6545",
-                                camera_id,
-                                tracker,
+                            msg = (
+                                f"Camera {camera_id} tracker {tracker} \u68c0\u6d4b\u5230\u4ea4\u901a\u4e8b\u6545"
                             )
+                            logger.warning(msg)
                             accident_detected = True
-                        else:
-                            logger.warning(
-                                "Camera %s tracker %s \u68c0\u6d4b\u5230\u8f66\u8f86\u5f02\u5e38\u505c\u6b62",
+                            await asyncio.to_thread(
+                                save_alert,
+                                "accident",
+                                msg,
+                                image_key,
                                 camera_id,
-                                tracker,
                             )
+                        else:
+                            msg = (
+                                f"Camera {camera_id} tracker {tracker} \u68c0\u6d4b\u5230\u8f66\u8f86\u5f02\u5e38\u505c\u6b62"
+                            )
+                            logger.warning(msg)
                             abnormal_stop_detected = True
+                            await asyncio.to_thread(
+                                save_alert,
+                                "abnormal_stop",
+                                msg,
+                                image_key,
+                                camera_id,
+                            )
                         entry["detected"] = True
             else:
                 low_speed_tracker[camera_id].pop(tracker, None)
@@ -441,8 +505,18 @@ async def handle_message(msg: str) -> None:
         detection_dirs[tracker or -1] = sign
 
         if speed is not None and speed < -5:
-            logger.warning("Camera %s tracker %s \u68c0\u6d4b\u5230\u9006\u884c", camera_id, tracker)
+            msg = (
+                f"Camera {camera_id} tracker {tracker} \u68c0\u6d4b\u5230\u9006\u884c"
+            )
+            logger.warning(msg)
             wrong_way_detected = True
+            await asyncio.to_thread(
+                save_alert,
+                "wrong_way",
+                msg,
+                image_key,
+                camera_id,
+            )
 
         info = direction_stats[sign]
         info["count"] += 1
@@ -468,24 +542,45 @@ async def handle_message(msg: str) -> None:
         avg_speed = info["speed"] / info["count"]
         area_ratio = info["area"] / road_area if road_area else 0
         if avg_speed < 60 and info["count"] >= 6 and area_ratio > 0.5:
+            ratio = avg_speed_overall / EXPECTED_SPEED * 100 if EXPECTED_SPEED else 0
             severity = "light"
-            if avg_speed < 20:
+            if ratio < 20 or avg_speed < EXPECTED_SPEED * 0.2:
                 severity = "severe"
-            elif avg_speed < 40:
+            elif ratio < 40 or avg_speed < EXPECTED_SPEED * 0.4:
                 severity = "medium"
+            msg = (
+                f"Camera {camera_id} congestion {severity} dir {sign} (avg_speed {avg_speed:.1f} km/h ratio {ratio:.1f}% count {info['count']} area_ratio {area_ratio:.2f})"
+            )
             logger.warning(
-                "Camera %s congestion %s dir %d (avg_speed %.1f km/h count %d area_ratio %.2f)",
+                "Camera %s congestion %s dir %d (avg_speed %.1f km/h ratio %.1f%% count %d area_ratio %.2f)",
                 camera_id,
                 severity,
                 sign,
                 avg_speed,
+                ratio,
                 info["count"],
                 area_ratio,
             )
+            if severity in {"medium", "severe"}:
+                await asyncio.to_thread(
+                    save_alert,
+                    f"congestion_{severity}",
+                    msg,
+                    image_key,
+                    camera_id,
+                )
 
     if wrong_way_ids:
+        msg = f"Camera {camera_id} wrong-way trackers: {wrong_way_ids}"
         logger.warning("Camera %s wrong-way trackers: %s", camera_id, wrong_way_ids)
         wrong_way_detected = True
+        await asyncio.to_thread(
+            save_alert,
+            "wrong_way",
+            msg,
+            image_key,
+            camera_id,
+        )
 
     if not detections:
         # Fallback when message lacks explicit shape information.


### PR DESCRIPTION
## Summary
- write traffic event logs to `logs.txt`
- store alert logs and images when congestion or anomalies occur
- add startup delay and cooldown when saving alerts
- only alert when congestion is medium or severe and record speed ratio

## Testing
- `python -m py_compile python_demos/video_surveillance_demo/websocket_client/traffic_post_processor.py`


------
https://chatgpt.com/codex/tasks/task_e_687182b30e308325ab1886eb17900638