### PR TITLE
Fix double counting vehicles

### DIFF
--- a/python_demos/video_surveillance_demo/websocket_client/traffic_post_processor.py
+++ b/python_demos/video_surveillance_demo/websocket_client/traffic_post_processor.py
@@ -17,7 +17,8 @@ import math
 # Flags that represent vehicle classes in the received JSON. These are used
 # when attempting to categorise a detected vehicle from the flags field. The
 # program no longer strictly filters by these categories so that any provided
-# label can be counted.
+# label can be counted.  The generic "vehicle" label is ignored when tallying
+# totals to avoid double counting both the parent and child categories.
 VEHICLE_CATEGORIES = ["car", "Truck", "SUV", "Motor", "mianbao", "sanlun"]
 ACCIDENT_WORKFLOW_ID = 52
 ACCIDENT_NODE_ID = "a3dc06bc-fd72-4941-a5c7-9be854192370"
@@ -481,8 +482,9 @@ async def handle_message(msg: str) -> None:
     detection_dirs: Dict[int, int] = {}
     now = time.time()
     for det in detections:
-        if det.get("cls"):
-            frame_counts[det["cls"]] += 1
+        cls = det.get("cls")
+        if cls and cls != "vehicle":
+            frame_counts[cls] += 1
 
         box = det.get("box")
         if box is None:
@@ -657,7 +659,10 @@ async def handle_message(msg: str) -> None:
             or data.get("label")
         )
         vehicle_cls = str(vehicle_cls).lower() if vehicle_cls else None
-        if vehicle_cls and vehicle_cls not in {"people", "person", "pedestrian"}:
+        if (
+            vehicle_cls
+            and vehicle_cls not in {"people", "person", "pedestrian", "vehicle"}
+        ):
             vehicle_counts[camera_id][vehicle_cls] += 1
         previous_boxes[camera_id] = []
     else:
@@ -671,7 +676,7 @@ async def handle_message(msg: str) -> None:
                 if iou(box, prev_box) >= IOU_THRESHOLD:
                     matched = True
                     break
-            if not matched and cls:
+            if not matched and cls and cls != "vehicle":
                 vehicle_counts[camera_id][cls] += 1
             new_boxes.append((box, cls or ""))
         previous_boxes[camera_id] = new_boxes


### PR DESCRIPTION
## Summary
- ignore generic `vehicle` label in traffic post-processing
- update comment to document ignoring generic label

## Testing
- `python -m py_compile python_demos/video_surveillance_demo/websocket_client/traffic_post_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_68731192bad08325809241939320dbc9